### PR TITLE
fix: missing dependency tox

### DIFF
--- a/setup.cfg.jinja
+++ b/setup.cfg.jinja
@@ -28,6 +28,7 @@ zip_safe = True
 include_package_data = True
 install_requires =
   boto3
+  tox
   requests
   cfn_resource_provider
 


### PR DESCRIPTION
tox is not installed on my local system, and `make test` executes `pipenv run tox`. That suggests that tox should be installed within the pipenv. Hence adding it as a dependency in the setup.cfg.